### PR TITLE
Revert "chore(deps): Bump softprops/action-gh-release from 2.1.0 to 2.2.0"

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -29,7 +29,7 @@ jobs:
           sha256sum CC*.pdf | tee sha256sums.txt
           b2sum CC*.pdf | tee b2sums.txt
       - name: Release
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@v2.1.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true


### PR DESCRIPTION
Reverts sorairolake/creative-commons-asciidoc#10